### PR TITLE
fix swapped vid and pid, fix input_devices instead of input_device

### DIFF
--- a/source/input_device.c
+++ b/source/input_device.c
@@ -50,7 +50,7 @@ void input_devices_remove(input_device_t *input_device)
 		fake_wiimote_release_input_device(wiimote);
 		fake_wiimote_disconnect(wiimote);
 	}
-	input_devices->valid = false;
+	input_device->valid = false;
 }
 
 void input_devices_tick(void)

--- a/source/usb_hid.c
+++ b/source/usb_hid.c
@@ -281,7 +281,7 @@ static int usb_device_ops_resume(void *usrdata, fake_wiimote_t *wiimote)
 	device->wiimote = wiimote;
 
 	if (device->driver->init)
-		return device->driver->init(device, device->pid, device->vid);
+		return device->driver->init(device, device->vid, device->pid);
 
 	return 0;
 }


### PR DESCRIPTION
While trying to implement PS3 instrument support, i noted that vid and pid were swapped, which was causing my code to never get called

I was also trying to work out why hotplugging devices didn't seem to be working, and while i could not figure that one out, i did note that there was an `input_devices` instead of a `input_device`. 