### PR TITLE
Mark the fake wiimote as inactive before disconnecting it

### DIFF
--- a/source/fake_wiimote.c
+++ b/source/fake_wiimote.c
@@ -309,6 +309,8 @@ int fake_wiimote_disconnect(fake_wiimote_t *wiimote)
 {
 	int ret = 0;
 
+	wiimote->active = false;
+
 	/* Unassign the currently assigned input device (if any) */
 	if (wiimote->input_device)
 		input_device_release_wiimote(wiimote->input_device);
@@ -319,8 +321,6 @@ int fake_wiimote_disconnect(fake_wiimote_t *wiimote)
 		ret = inject_hci_event_discon_compl(wiimote->hci_con_handle,
 						    0, 0x13 /* User Ended Connection */);
 	}
-
-	wiimote->active = false;
 
 	return ret;
 }


### PR DESCRIPTION
When testing hotplug, i found that unplugging and replugging the controller would sometimes just hang my wii. It was actually this behaviour that was why my guitar hero branch sort of sat stale for so long, as I couldn't really share a build of it with people when it was causing their wii to hang.

However, marking the controller as inactive before unassigning and disconnecting it seems to have fixed this, I was able to unplug and replug my guitar hero guitar without it hanging with IOS57.